### PR TITLE
[Feat] : 회원 도메인 개발

### DIFF
--- a/Practice/src/main/java/Spring/Practice/repository/MemberRepository.java
+++ b/Practice/src/main/java/Spring/Practice/repository/MemberRepository.java
@@ -1,0 +1,38 @@
+package Spring.Practice.repository;
+
+import Spring.Practice.domain.Member;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+@Transactional(readOnly = true)
+public class MemberRepository {
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Transactional
+	public Long save(Member member) {
+		em.persist(member);
+		return member.getId();
+	}
+
+	public Member findOne(Long id) {
+		return em.find(Member.class, id);
+	}
+
+	public List<Member> findAll() {
+		return em.createQuery("select m from Member m", Member.class)
+				.getResultList();
+	}
+
+	public List<Member> findByName(String param) {
+		return em.createQuery("select m from Member m where m.name = :param", Member.class)
+				.setParameter("param", param)
+				.getResultList();
+	}
+}

--- a/Practice/src/main/java/Spring/Practice/service/MemberService.java
+++ b/Practice/src/main/java/Spring/Practice/service/MemberService.java
@@ -1,0 +1,42 @@
+package Spring.Practice.service;
+
+import Spring.Practice.domain.Member;
+import Spring.Practice.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+	@Autowired
+	public MemberService(MemberRepository memberRepository) {
+		this.memberRepository = memberRepository;
+	}
+
+	@Transactional
+	public Long join(Member member) {
+		isDuplicateMember(member);
+		memberRepository.save(member);
+		return member.getId();
+	}
+
+	private void isDuplicateMember(Member member) {
+		List<Member> members = memberRepository.findByName(member.getName());
+		if (!members.isEmpty()) {
+			throw new IllegalStateException("이미 존재하는 회원입니다.");
+		}
+	}
+
+	public List<Member> findMembers() {
+		return memberRepository.findAll();
+	}
+
+	public Member findOne(Long memberId) {
+		return memberRepository.findOne(memberId);
+	}
+}

--- a/Practice/src/test/java/Spring/Practice/service/MemberServiceTest.java
+++ b/Practice/src/test/java/Spring/Practice/service/MemberServiceTest.java
@@ -1,0 +1,51 @@
+package Spring.Practice.service;
+
+import Spring.Practice.domain.Member;
+import Spring.Practice.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+	@Autowired MemberService memberService;
+	@Autowired MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("회원가입 테스트")
+	void join() throws Exception {
+		// given
+		Member member = new Member();
+		member.setName("Kim");
+
+		// when
+		Long id = memberService.join(member);
+
+		// then
+		Assertions.assertThat(member).isEqualTo(memberRepository.findOne(id));
+	}
+
+	@Test
+	@DisplayName("중복 회원 검증")
+	void isDuplicateMember() throws Exception {
+		// given
+		Member m1 = new Member();
+		m1.setName("Kim");
+
+		Member m2 = new Member();
+		m2.setName("Kim");
+
+		// when
+		memberService.join(m1);
+
+		// then
+		assertThrows(IllegalStateException.class, () -> memberService.join(m2));
+	}
+}


### PR DESCRIPTION
### 회원 도메인 개발

**구현 기능**
- 회원 등록
- 회원 목록 조회

### 공부한 내용

- [ ] `@Transactional` : 트랜잭션, 영속성 컨텍스트 → `readOnly=true` : 데이터 변경이 없는 읽기 전용 메서드에만 사용, 영속성 컨텍스트를 플러시 하지 않으므로 약간의 성능 향상
- [ ] 테스트 코드에서의 `@Transactional` : 반복 가능한 테스트 지원, 각각의 테스트를 실행할 때마다 트랜잭션을 시작하고 테스트가 끝나면 트랜잭션을 강제로 롤백