### PR TITLE
[Refactor] : API 개발 기본 - 지연 로딩(LAZY)과 조회 성능 최적화

### DIFF
--- a/Practice/build.gradle
+++ b/Practice/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// https://mvnrepository.com/artifact/com.github.gavlyukovskiy/p6spy-spring-boot-starter
+	implementation group: 'com.github.gavlyukovskiy', name: 'p6spy-spring-boot-starter', version: '1.9.1'
+
 }
 
 tasks.named('test') {

--- a/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
@@ -3,6 +3,7 @@ package Spring.Practice.api;
 import Spring.Practice.domain.Member;
 import Spring.Practice.service.MemberService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,6 +25,15 @@ public class MemberApiController {
 		return new CreateMemberResponse(id);
 	}
 
+	@PostMapping("/api/v2/members")
+	public CreateMemberResponse saveMemberV2(@RequestBody @Valid CreateMemberRequest request) {
+		Member member = new Member();
+		member.setId(request.getId());
+		member.setName(request.getName());
+		Long id = memberService.join(member);
+		return new CreateMemberResponse(id);
+	}
+
 	@Data
 	static class CreateMemberResponse {
 		private Long id;
@@ -31,5 +41,13 @@ public class MemberApiController {
 		public CreateMemberResponse(Long id) {
 			this.id = id;
 		}
+	}
+
+	@Data
+	static class CreateMemberRequest {
+		private Long id;
+
+		@NotEmpty
+		private String name;
 	}
 }

--- a/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 public class MemberApiController {
@@ -45,6 +46,37 @@ public class MemberApiController {
 	@GetMapping("/api/v1/members")
 	public List<Member> membersV1() {
 		return memberService.findMembers();
+	}
+
+	// Result 제네릭 클래스로 컬렉션을 감싸면 향후 필요한 필드 추가도 쉽게 할 수 있다.
+	// 컬렉션을 직접 반환하게 되면 향후 API 스펙을 변경하기가 매우 까다로워진다.
+	// 별도의 Result 클래스 생성으로 해결이 가능하다.ㄷ
+	@GetMapping("/api/v2/members")
+	public Result membersV2() {
+		List<Member> members = memberService.findMembers();
+		List<MemberDTO> collect = members.stream()
+				.map(member -> new MemberDTO(member.getName()))
+				.collect(Collectors.toList());
+		return new Result(collect);
+	}
+
+	// 제네릭 도입
+	@Data
+	static class Result<T> {
+		private T data;
+
+		public Result(T data) {
+			this.data = data;
+		}
+	}
+
+	@Data
+	static class MemberDTO {
+		private String name;
+
+		public MemberDTO(String name) {
+			this.name = name;
+		}
 	}
 
 	@Data

--- a/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
@@ -6,9 +6,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class MemberApiController {
@@ -34,6 +32,15 @@ public class MemberApiController {
 		return new CreateMemberResponse(id);
 	}
 
+	@PutMapping("/api/v2/members/{id}")
+	public UpdateMemberResponse updateMemberV2(@PathVariable(name = "id") Long id, @RequestBody @Valid UpdateMemberRequest request) {
+		// 변경의 경우 가급적 반환값이 없게끔 설계하는 것이 좋다.
+		memberService.update(id, request.getName());
+		Member member = memberService.findOne(id);
+		return new UpdateMemberResponse(member.getId(), member.getName());
+	}
+
+
 	@Data
 	static class CreateMemberResponse {
 		private Long id;
@@ -48,6 +55,22 @@ public class MemberApiController {
 		private Long id;
 
 		@NotEmpty
+		private String name;
+	}
+
+	@Data
+	static class UpdateMemberResponse {
+		private Long id;
+		private String name;
+
+		public UpdateMemberResponse(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+
+	@Data
+	static class UpdateMemberRequest {
 		private String name;
 	}
 }

--- a/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
@@ -1,0 +1,35 @@
+package Spring.Practice.api;
+
+import Spring.Practice.domain.Member;
+import Spring.Practice.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberApiController {
+
+	private final MemberService memberService;
+	@Autowired
+	public MemberApiController(MemberService memberService) {
+		this.memberService = memberService;
+	}
+
+	@PostMapping("/api/v1/members")
+	public CreateMemberResponse saveMemberV1(@RequestBody @Valid Member member) {
+		Long id = memberService.join(member);
+		return new CreateMemberResponse(id);
+	}
+
+	@Data
+	static class CreateMemberResponse {
+		private Long id;
+
+		public CreateMemberResponse(Long id) {
+			this.id = id;
+		}
+	}
+}

--- a/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/MemberApiController.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 public class MemberApiController {
 
@@ -40,6 +42,10 @@ public class MemberApiController {
 		return new UpdateMemberResponse(member.getId(), member.getName());
 	}
 
+	@GetMapping("/api/v1/members")
+	public List<Member> membersV1() {
+		return memberService.findMembers();
+	}
 
 	@Data
 	static class CreateMemberResponse {

--- a/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
@@ -33,6 +33,16 @@ public class OrderApiController {
 		return new Result(collect);
 	}
 
+	// 기본적으로는 LAZY Loading(지연 로딩)
+	// 필요한 것들만 객체 그래프로 탐색하여 한 번에 가져오도록 하는 것(페치 조인)
+	@GetMapping("/api/v3/simple-orders")
+	public List<SimpleOrderDTO> ordersV3() {
+		List<Order> all = orderRepository.findAllWithMemberDelivery();
+		return all.stream()
+				.map(order -> new SimpleOrderDTO(order))
+				.collect(Collectors.toList());
+	}
+
 	@Data
 	static class SimpleOrderDTO {
 		private Long orderId;

--- a/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
@@ -1,0 +1,63 @@
+package Spring.Practice.api;
+
+import Spring.Practice.domain.Address;
+import Spring.Practice.domain.Order;
+import Spring.Practice.domain.enumType.OrderStatus;
+import Spring.Practice.repository.OrderRepository;
+import Spring.Practice.service.OrderService;
+import Spring.Practice.util.OrderSearch;
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+public class OrderApiController {
+
+	private final OrderRepository orderRepository;
+	@Autowired
+	public OrderApiController(OrderRepository orderRepository) {
+		this.orderRepository = orderRepository;
+	}
+
+	@GetMapping("/api/v2/simple-orders")
+	public Result ordersV1() {
+		List<Order> all = orderRepository.findAllByString(new OrderSearch());
+		List<SimpleOrderDTO> collect = all.stream()
+				.map(order -> new SimpleOrderDTO(order))
+				.collect(Collectors.toList());
+		return new Result(collect);
+	}
+
+	@Data
+	static class SimpleOrderDTO {
+		private Long orderId;
+		private String name;
+		private LocalDateTime orderDate;
+		private OrderStatus orderStatus;
+		private Address address;
+
+		// LAZY(지연로딩) → 프록시(객체)
+		// 해당 엔티티의 메서드를 호출하는 순간 실제 메서드가 됨
+		public SimpleOrderDTO(Order order) {
+			orderId = order.getId();
+			name = order.getMember().getName();			// 여기서 한 번!
+			orderDate = order.getOrderDate();
+			orderStatus = order.getStatus();
+			address = order.getDelivery().getAddress();	// 여기서 한 번!
+		}
+	}
+
+	@Data
+	static class Result<T> {
+		private T value;
+
+		public Result(T value) {
+			this.value = value;
+		}
+	}
+}

--- a/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
@@ -4,8 +4,8 @@ import Spring.Practice.domain.Address;
 import Spring.Practice.domain.Order;
 import Spring.Practice.domain.enumType.OrderStatus;
 import Spring.Practice.repository.OrderRepository;
-import Spring.Practice.service.OrderService;
 import Spring.Practice.util.OrderSearch;
+import Spring.Practice.util.SimpleOrderQueryDTO;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,6 +41,11 @@ public class OrderApiController {
 		return all.stream()
 				.map(order -> new SimpleOrderDTO(order))
 				.collect(Collectors.toList());
+	}
+
+	@GetMapping("/api/v4/simple-orders")
+	public List<SimpleOrderQueryDTO> ordersV4() {
+		return orderRepository.findOrderDtos();
 	}
 
 	@Data

--- a/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
@@ -25,7 +25,7 @@ public class OrderApiController {
 	}
 
 	@GetMapping("/api/v2/simple-orders")
-	public Result ordersV1() {
+	public Result ordersV2() {
 		List<Order> all = orderRepository.findAllByString(new OrderSearch());
 		List<SimpleOrderDTO> collect = all.stream()
 				.map(order -> new SimpleOrderDTO(order))

--- a/Practice/src/main/java/Spring/Practice/repository/OrderRepository.java
+++ b/Practice/src/main/java/Spring/Practice/repository/OrderRepository.java
@@ -66,4 +66,10 @@ public class OrderRepository {
 		}
 		return result.getResultList();
 	}
+
+	// 페치 조인 최적화
+	public List<Order> findAllWithMemberDelivery() {
+		return em.createQuery("select o from Order o join fetch o.member m join fetch o.delivery d", Order.class)
+				.getResultList();
+	}
 }

--- a/Practice/src/main/java/Spring/Practice/repository/OrderRepository.java
+++ b/Practice/src/main/java/Spring/Practice/repository/OrderRepository.java
@@ -2,6 +2,7 @@ package Spring.Practice.repository;
 
 import Spring.Practice.domain.Order;
 import Spring.Practice.util.OrderSearch;
+import Spring.Practice.util.SimpleOrderQueryDTO;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
@@ -70,6 +71,12 @@ public class OrderRepository {
 	// 페치 조인 최적화
 	public List<Order> findAllWithMemberDelivery() {
 		return em.createQuery("select o from Order o join fetch o.member m join fetch o.delivery d", Order.class)
+				.getResultList();
+	}
+
+	// JPA에서 DTO로 바로 조회할 수 있도록 하기 위해 만든 DTO
+	public List<SimpleOrderQueryDTO> findOrderDtos() {
+		return em.createQuery("select new Spring.Practice.util.SimpleOrderQueryDTO(o.id, m.name, o.orderDate, o.status, d.address) from Order o join o.member m join o.delivery d", SimpleOrderQueryDTO.class)
 				.getResultList();
 	}
 }

--- a/Practice/src/main/java/Spring/Practice/service/MemberService.java
+++ b/Practice/src/main/java/Spring/Practice/service/MemberService.java
@@ -39,4 +39,11 @@ public class MemberService {
 	public Member findOne(Long memberId) {
 		return memberRepository.findOne(memberId);
 	}
+
+	// 수정 → 가급적이면 변경 감지(Dirty Checking)
+	@Transactional
+	public void update(Long id, String name) {
+		Member member = memberRepository.findOne(id);
+		member.setName(name);
+	}
 }

--- a/Practice/src/main/java/Spring/Practice/util/SimpleOrderQueryDTO.java
+++ b/Practice/src/main/java/Spring/Practice/util/SimpleOrderQueryDTO.java
@@ -1,0 +1,26 @@
+package Spring.Practice.util;
+
+import Spring.Practice.domain.Address;
+import Spring.Practice.domain.Order;
+import Spring.Practice.domain.enumType.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class SimpleOrderQueryDTO {
+	private Long orderId;
+	private String name;
+	private LocalDateTime orderDate;
+	private OrderStatus orderStatus;
+	private Address address;
+	
+	// 모든 파라미터를 전부 다 등록
+	public SimpleOrderQueryDTO(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address) {
+		this.orderId = orderId;
+		this.name = name;
+		this.orderDate = orderDate;
+		this.orderStatus = orderStatus;
+		this.address = address;
+	}
+}


### PR DESCRIPTION
###  지연 로딩과 조회 성능 최적화

**방법**
- 엔티티를 직접 노출시키기❌
- 엔티티를 DTO로 변환하는 일반적인 방법❓
- 엔티티를 DTO로 변환하되 지연 로딩으로 설정된 연관관계의 조회 성능 최적화를 위한 페치 조인(Fetch Join) 도입하여 조인 적용 후 DTO로 변환⭕
- JPA에서 DTO를 바로 조회⭕

### 공부한 내용

- [ ] 엔티티를 직접 노출시키기❌

  - 이 방법은 권장되는 방법이 아니다.
  - 어떤 API를 개발하냐에 따라서 다르겠지만 요구사항마다 제약 조건이 추가될 수 있다.
  - A API 스펙에서는 제약 조건이 필요하지만 B API 스펙에서는 제약 조건이 필요하지 않다고 가정할 때 프레젠테이션 계층을 위한 제약 조건을 엔티티에 추가하면 제약 조건이 필요하지 않은 B API를 개발하는데 차질을 빚을 수 있다.
  - 엔티티를 외부에 직접적으로 노출시키는 것은 매우 좋지 않다.

- [ ] 엔티티를 DTO로 변환하는 일반적인 방법❓

  - DTO란, Data Transfer Object의 약자로 데이터 전달용 객체를 뜻한다.
  - 하지만 연관관계가 `@ManyToOne`, `@OneToOne`과 같은 연관관계의 경우 지연 로딩(LAZY)을 적용하는데 이 때, `N + 1` 문제가 발생한다.

- [ ] 엔티티를 DTO로 변환하되 지연 로딩으로 설정된 연관관계의 조회 성능 최적화를 위한 페치 조인(Fetch Join) 도입하여 조인 적용 후 DTO로 변환⭕

  - 거의 90%의 성능 향상을 보장한다.
  - 엔티티를 페치 조인을 사용해서 쿼리 1번에 조회할 수 있다.
  - 지연 로딩으로 설정했다 하더라도 연관관계에 대해 이미 조회를 한 상황이므로 지연로딩이 적용되지 않는다.

- [ ] JPA에서 DTO를 바로 조회⭕

  - 일반적인 SQL을 사용할 때와 같이 원하는 값을 선택해서 조회하도록 한다.
  - `new` 명령어를 사용해서 전체 패키지 경로를 명시하고 JPQL의 결과를 DTO로 즉시 변환한다.
  - 해당 코드는 API 스펙에 맞춘 별도의 코드를 작성해야하며 리포지토리의 재사용성이 떨어진다.

### 최종 결론

1. 우선 엔티티를 DTO로 변환하는 방식을 1순위로 채택하되 페치 조인을 적용한다.
2. 그래도 성능 향상을 도모할 수 없다면 2순위로 DTO로 직접 조회하는 방법을 채택한다.