### PR TITLE
[Refactor] : API 개발 고급 - 컬렉션 조회 최적화

### DIFF
--- a/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
@@ -74,6 +74,11 @@ public class OrderApiController {
 		return orderQueryRepository.findOrderQueryDtos();
 	}
 
+	@GetMapping("/api/v5/orders")
+	public List<OrderQueryDto> ordersV5() {
+		return orderQueryRepository.findAllByDto_optimization();
+	}
+
 	@Data
 	static class OrderDto {
 		private Long orderId;

--- a/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
@@ -5,6 +5,8 @@ import Spring.Practice.domain.Order;
 import Spring.Practice.domain.OrderItem;
 import Spring.Practice.domain.enumType.OrderStatus;
 import Spring.Practice.repository.OrderRepository;
+import Spring.Practice.repository.order.query.OrderQueryDto;
+import Spring.Practice.repository.order.query.OrderQueryRepository;
 import Spring.Practice.service.OrderService;
 import Spring.Practice.util.OrderSearch;
 import lombok.Data;
@@ -22,11 +24,13 @@ import java.util.stream.Collectors;
 public class OrderApiController {
 
 	private final OrderService orderService;
+	private final OrderQueryRepository orderQueryRepository;
 	private final OrderRepository orderRepository;
 
 	@Autowired
-	public OrderApiController(OrderService orderService, OrderRepository orderRepository) {
+	public OrderApiController(OrderService orderService, OrderQueryRepository orderQueryRepository, OrderRepository orderRepository) {
 		this.orderService = orderService;
+		this.orderQueryRepository = orderQueryRepository;
 		this.orderRepository = orderRepository;
 	}
 
@@ -63,6 +67,11 @@ public class OrderApiController {
 		return all.stream()
 				.map(order -> new OrderDto(order))
 				.collect(Collectors.toList());
+	}
+
+	@GetMapping("/api/v4/orders")
+	public List<OrderQueryDto> ordersV4() {
+		return orderQueryRepository.findOrderQueryDtos();
 	}
 
 	@Data

--- a/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
@@ -11,6 +11,7 @@ import lombok.Data;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
@@ -48,6 +49,17 @@ public class OrderApiController {
 	@GetMapping("/api/v3/orders")
 	public List<OrderDto> ordersV3() {
 		List<Order> all = orderRepository.findAllWithItem();
+		return all.stream()
+				.map(order -> new OrderDto(order))
+				.collect(Collectors.toList());
+	}
+
+	@GetMapping("/api/v3.1/orders")
+	public List<OrderDto> ordersV3page(
+			@RequestParam(name = "offset", defaultValue = "0") int offset,
+			@RequestParam(name = "limit", defaultValue = "100") int limit
+	) {
+		List<Order> all = orderRepository.findAllWithMemberDelivery(offset, limit);
 		return all.stream()
 				.map(order -> new OrderDto(order))
 				.collect(Collectors.toList());

--- a/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
@@ -1,0 +1,77 @@
+package Spring.Practice.api;
+
+import Spring.Practice.domain.Address;
+import Spring.Practice.domain.Order;
+import Spring.Practice.domain.OrderItem;
+import Spring.Practice.domain.enumType.OrderStatus;
+import Spring.Practice.repository.OrderRepository;
+import Spring.Practice.service.OrderService;
+import Spring.Practice.util.OrderSearch;
+import lombok.Data;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+public class OrderApiController {
+
+	private final OrderService orderService;
+	private final OrderRepository orderRepository;
+
+	@Autowired
+	public OrderApiController(OrderService orderService, OrderRepository orderRepository) {
+		this.orderService = orderService;
+		this.orderRepository = orderRepository;
+	}
+
+	// 지연 로딩으로 인한 너무 많은 SQL 실행이 문제가 됨
+	// 컬렉션도 DTO로 별도로 만들어주어야 한다.
+	// Ex. OrderItems → OrderItemDto
+	@GetMapping("/api/v2/orders")
+	public List<OrderDto> ordersV2() {
+		List<Order> all = orderRepository.findAllByString(new OrderSearch());
+		return all.stream()
+				.map(order -> new OrderDto(order))
+				.collect(Collectors.toList());
+	}
+
+	@Data
+	static class OrderDto {
+		private Long orderId;
+		private String name;
+		private LocalDateTime orderDate;
+		private OrderStatus orderStatus;
+		private Address address;
+		private List<OrderItemDto> orderItems;
+
+		public OrderDto(Order order) {
+			orderId = order.getId();
+			name = order.getMember().getName();
+			orderDate = order.getOrderDate();
+			orderStatus = order.getStatus();
+			address = order.getDelivery().getAddress();
+			orderItems = order.getOrderItems()
+					.stream()
+					.map(orderItem -> new OrderItemDto(orderItem))
+					.collect(Collectors.toList());
+		}
+	}
+
+	@Getter
+	static class OrderItemDto {
+		private String itemName; // 상품명
+		private int orderPrice;	 // 주문 가격
+		private int count;		 // 주문 수량
+		
+		public OrderItemDto(OrderItem orderItem) {
+			itemName = orderItem.getItem().getName();
+			orderPrice = orderItem.getOrderPrice();
+			count = orderItem.getCount();
+		}
+	}
+}

--- a/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
+++ b/Practice/src/main/java/Spring/Practice/api/OrderApiController.java
@@ -40,6 +40,19 @@ public class OrderApiController {
 				.collect(Collectors.toList());
 	}
 
+	// 페치 조인 적용
+	// "select distinct o from Order o join fetch o.member m join fetch o.delivery d join fetch o.orderItems oi join fetch oi.item i"
+	// 페치 조인으로 SQL 1번만 실행됨
+	// distinct를 사용하는 이유는 애플리케이션에서 중복을 걸러준다.
+	// 페이징 불가능
+	@GetMapping("/api/v3/orders")
+	public List<OrderDto> ordersV3() {
+		List<Order> all = orderRepository.findAllWithItem();
+		return all.stream()
+				.map(order -> new OrderDto(order))
+				.collect(Collectors.toList());
+	}
+
 	@Data
 	static class OrderDto {
 		private Long orderId;

--- a/Practice/src/main/java/Spring/Practice/init/InitDb.java
+++ b/Practice/src/main/java/Spring/Practice/init/InitDb.java
@@ -1,0 +1,93 @@
+package Spring.Practice.init;
+
+import Spring.Practice.domain.Delivery;
+import Spring.Practice.domain.Member;
+import Spring.Practice.domain.Order;
+import Spring.Practice.domain.Address;
+import Spring.Practice.domain.OrderItem;
+import Spring.Practice.domain.item.Book;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class InitDb {
+
+	private final InitService initService;
+	@Autowired
+	public InitDb(InitService initService) {
+		this.initService = initService;
+	}
+
+	@PostConstruct
+	public void init() {
+		initService.dbInit1();
+		initService.dbInit2();
+	}
+
+	@Component
+	@Transactional
+	@RequiredArgsConstructor
+	static class InitService {
+
+		private final EntityManager em;
+
+		public void dbInit1() {
+			Member member = createMember("userA", "서울", "1", "1111");
+			em.persist(member);
+			Book book1 = createBook("JPA1 BOOK", 10000, 100);
+			em.persist(book1);
+			Book book2 = createBook("JPA2 BOOK", 20000, 100);
+			em.persist(book2);
+			OrderItem orderItem1 = OrderItem.createOrderItem(book1, 10000, 1);
+			OrderItem orderItem2 = OrderItem.createOrderItem(book2, 20000, 2);
+			Order order = Order.createOrder(member, createDelivery(member),
+					orderItem1, orderItem2);
+			em.persist(order);
+		}
+
+
+		public void dbInit2() {
+			Member member = createMember("userB", "진주", "2", "2222");
+			em.persist(member);
+			Book book1 = createBook("SPRING1 BOOK", 20000, 200);
+			em.persist(book1);
+			Book book2 = createBook("SPRING2 BOOK", 40000, 300);
+			em.persist(book2);
+			Delivery delivery = createDelivery(member);
+			OrderItem orderItem1 = OrderItem.createOrderItem(book1, 20000, 3);
+			OrderItem orderItem2 = OrderItem.createOrderItem(book2, 40000, 4);
+			Order order = Order.createOrder(member, delivery, orderItem1,
+					orderItem2);
+			em.persist(order);
+		}
+
+
+		private Member createMember(String name, String city, String street,
+									String zipcode) {
+			Member member = new Member();
+			member.setName(name);
+			member.setAddress(new Address(city, street, zipcode));
+			return member;
+		}
+
+
+		private Book createBook(String name, int price, int stockQuantity) {
+			Book book = new Book();
+			book.setName(name);
+			book.setPrice(price);
+			book.setStockQuantity(stockQuantity);
+			return book;
+		}
+
+
+		private Delivery createDelivery(Member member) {
+			Delivery delivery = new Delivery();
+			delivery.setAddress(member.getAddress());
+			return delivery;
+		}
+	}
+}

--- a/Practice/src/main/java/Spring/Practice/repository/OrderRepository.java
+++ b/Practice/src/main/java/Spring/Practice/repository/OrderRepository.java
@@ -74,12 +74,25 @@ public class OrderRepository {
 				.getResultList();
 	}
 
+	// 일대다 컬렉션 조회 및 페이징을 적용한 솔루션
+	public List<Order> findAllWithMemberDelivery(int offset, int limit) {
+		// Order - Member : 다대일 관계
+		// Order - Delivery : 일대일 관계
+		// [1]. @XToOne → 다대일/일대일 관계를 모두 페치 조인하기
+		return em.createQuery("select o from Order o join fetch o.member m join fetch o.delivery d", Order.class)
+				.setFirstResult(offset)
+				.setMaxResults(limit)
+				.getResultList();
+	}
+
 	// JPA에서 DTO로 바로 조회할 수 있도록 하기 위해 만든 DTO
 	public List<SimpleOrderQueryDTO> findOrderDtos() {
 		return em.createQuery("select new Spring.Practice.util.SimpleOrderQueryDTO(o.id, m.name, o.orderDate, o.status, d.address) from Order o join o.member m join o.delivery d", SimpleOrderQueryDTO.class)
 				.getResultList();
 	}
 
+	// 다대일/일대일 관계 : 페치 조인 적용
+	// 컬렉션 페치 조인
 	public List<Order> findAllWithItem() {
 		return em.createQuery("select distinct o from Order o join fetch o.member m join fetch o.delivery d join fetch o.orderItems oi join fetch oi.item i", Order.class)
 				.getResultList();

--- a/Practice/src/main/java/Spring/Practice/repository/OrderRepository.java
+++ b/Practice/src/main/java/Spring/Practice/repository/OrderRepository.java
@@ -79,4 +79,9 @@ public class OrderRepository {
 		return em.createQuery("select new Spring.Practice.util.SimpleOrderQueryDTO(o.id, m.name, o.orderDate, o.status, d.address) from Order o join o.member m join o.delivery d", SimpleOrderQueryDTO.class)
 				.getResultList();
 	}
+
+	public List<Order> findAllWithItem() {
+		return em.createQuery("select distinct o from Order o join fetch o.member m join fetch o.delivery d join fetch o.orderItems oi join fetch oi.item i", Order.class)
+				.getResultList();
+	}
 }

--- a/Practice/src/main/java/Spring/Practice/repository/order/query/OrderItemQueryDto.java
+++ b/Practice/src/main/java/Spring/Practice/repository/order/query/OrderItemQueryDto.java
@@ -1,0 +1,18 @@
+package Spring.Practice.repository.order.query;
+
+import lombok.Data;
+
+@Data
+public class OrderItemQueryDto {
+	private Long orderId;
+	private String itemName;
+	private int orderPrice;
+	private int count;
+
+	public OrderItemQueryDto(Long orderId, String itemName, int orderPrice, int count) {
+		this.orderId = orderId;
+		this.itemName = itemName;
+		this.orderPrice = orderPrice;
+		this.count = count;
+	}
+}

--- a/Practice/src/main/java/Spring/Practice/repository/order/query/OrderQueryDto.java
+++ b/Practice/src/main/java/Spring/Practice/repository/order/query/OrderQueryDto.java
@@ -1,0 +1,26 @@
+package Spring.Practice.repository.order.query;
+
+import Spring.Practice.domain.Address;
+import Spring.Practice.domain.enumType.OrderStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class OrderQueryDto {
+	private Long orderId;
+	private String name;
+	private LocalDateTime orderDate;
+	private OrderStatus orderStatus;
+	private Address address;
+	private List<OrderItemQueryDto> orderItemQueryDtoList;
+
+	public OrderQueryDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address) {
+		this.orderId = orderId;
+		this.name = name;
+		this.orderDate = orderDate;
+		this.orderStatus = orderStatus;
+		this.address = address;
+	}
+}

--- a/Practice/src/main/java/Spring/Practice/repository/order/query/OrderQueryRepository.java
+++ b/Practice/src/main/java/Spring/Practice/repository/order/query/OrderQueryRepository.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 // 엔티티가 아닌 다른 것들을 조회하기 위한 별도의 리포지토리
 @Repository
@@ -34,7 +36,29 @@ public class OrderQueryRepository {
 				.setParameter("orderId", orderId)
 				.getResultList();
 	}
-	
+
+	public List<OrderQueryDto> findAllByDto_optimization() {
+		List<OrderQueryDto> result = findOrders();
+
+		// findOrders() → order의 식별자 orderId
+		// orderId 리스트
+		List<Long> orderIds = result.stream()
+				.map(o -> o.getOrderId())
+				.collect(Collectors.toList());
+
+		// 파라미터에 orderId리스트를 넣고 IN절 사용
+		List<OrderItemQueryDto> orderItems = em.createQuery("select new Spring.Practice.repository.order.query.OrderItemQueryDto(oi.order.id, i.name, oi.orderPrice, oi.count) from OrderItem oi join oi.item i where oi.order.id in :orderIds", OrderItemQueryDto.class)
+				.setParameter("orderIds", orderIds)
+				.getResultList();
+
+		// OrderItemQueryDto → (Long orderId, String itemName, int orderPrice, int count)
+		// 식별자 orderId를 가져와서 메모리 상에서 그룹화
+		// 그렇게 되면 하나의 orderId에 있는 OrderItem 컬렉션이 담기게 되고 orderId가 key, 컬렉션이 value가 됨
+		Map<Long, List<OrderItemQueryDto>> orderItemMap = orderItems.stream().collect(Collectors.groupingBy(orderItemQueryDto -> orderItemQueryDto.getOrderId()));
+		result.forEach(o -> o.setOrderItemQueryDtoList(orderItemMap.get(o.getOrderId())));
+		return result;
+	}
+
 	// [1]. ToOne 관계들을 먼저 처리
 	// ORDER : MEMBER = N : 1
 	// ORDER : DELIVERY = 1 : 1

--- a/Practice/src/main/java/Spring/Practice/repository/order/query/OrderQueryRepository.java
+++ b/Practice/src/main/java/Spring/Practice/repository/order/query/OrderQueryRepository.java
@@ -1,0 +1,46 @@
+package Spring.Practice.repository.order.query;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+// 엔티티가 아닌 다른 것들을 조회하기 위한 별도의 리포지토리
+@Repository
+@RequiredArgsConstructor
+public class OrderQueryRepository {
+
+	private final EntityManager em;
+
+	public List<OrderQueryDto> findOrderQueryDtos() {
+		// [1]. 컬렉션을 제외한 DTO 가져오기
+		// 이 때, OrderQueryDTO에는 private List<OrderItemQueryDto> orderItemQueryDtoList;가 존재
+		List<OrderQueryDto> result = findOrders();
+		// [2]. 루프를 돌리면서 컬렉션 OrderItemQueryDto 만들기
+		result.stream().forEach(orderQueryDto -> {
+			List<OrderItemQueryDto> orderItems = findOrderItems(orderQueryDto.getOrderId());
+			orderQueryDto.setOrderItemQueryDtoList(orderItems);
+		});
+		return result;
+	}
+
+	// ORDERITEM : ITEM = N : 1
+	// [2]. ToMany 관계는 이와 같이 별도로 처리
+	// private List<OrderItem> orderItems = new ArrayList<>();
+	// ORDERITEM → 내부 요소들에 대한 DTO(id, item, order, orderPrice, count)
+	private List<OrderItemQueryDto> findOrderItems(Long orderId) {
+		return em.createQuery("select new Spring.Practice.repository.order.query.OrderItemQueryDto(oi.order.id, i.name, oi.orderPrice, oi.count) from OrderItem oi join oi.item i where oi.order.id = :orderId", OrderItemQueryDto.class)
+				.setParameter("orderId", orderId)
+				.getResultList();
+	}
+	
+	// [1]. ToOne 관계들을 먼저 처리
+	// ORDER : MEMBER = N : 1
+	// ORDER : DELIVERY = 1 : 1
+	// 이 때, 컬렉션은 포함시키지 않는다.
+	private List<OrderQueryDto> findOrders() {
+		return em.createQuery("select new Spring.Practice.repository.order.query.OrderQueryDto(o.id, m.name, o.orderDate, o.status, d.address) from Order o join o.member m join o.delivery d", OrderQueryDto.class)
+				.getResultList();
+	}
+}

--- a/Practice/src/main/resources/application.yml
+++ b/Practice/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       enabled: true
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
       #ddl-auto: create
     properties:
       hibernate:

--- a/Practice/src/main/resources/application.yml
+++ b/Practice/src/main/resources/application.yml
@@ -17,10 +17,19 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        show_sql: true
+        # [2]. default_batch_fetch_size
+        # ToOne 관계는 페치 조인을 하더라도 페이징에 영향을 주지 않는다.
+        # 따라서 ToOne 관계는 페치 조인으로 쿼리 수를 줄이고 나머지는 default_batch_fetch_size로 최적화
+        # 적당한 사이즈를 골라야 하는데 100 ~ 1000 사이를 선택하는 것을 권장한다.
+        # IN절을 사용하는데 DB에 따라 IN절 파라미터를 1000으로 제한하기도 한다.
+        # 1000으로 잡으면 한 번에 1000개를 DB에서 애플리케이션에 불러오기에 순간 부하가 증가할 수 있으나 100이든 1000이든 전체 데이터를 로딩해야 하므로 메모리 사용량이 같다.
+        # 1000으로 설정하는 것이 가장 좋으나 DB든 애플리케이션이든 순간 부하를 어느 정도까지 견딜 수 있느냐로 결정하면 된다.
+        default_batch_fetch_size: 100
 
 logging:
   level:
     org:
       hibernate:
         sql: debug
-        type: trace
+        #type: trace


### PR DESCRIPTION
###  컬렉션 조회 최적화

- [x] 엔티티 조회 방식

  - 엔티티를 조회해서 그대로 변환❌
  - 엔티티 조회 후 DTO로 변환(V2)❓
  - 컬렉션 페치 조인(V3) + 키워드 `distinct` 중복 제거⭕
  - 컬렉션 페치 조인 및 페이징(V3.1) + `@XToOne` 관계 모두 페치 조인 + `application.yml` 설정 파일에 `default_batch_fetch_size` 추가하여 배치 사이즈 조정👍⭕

- [ ] DTO 조회 방식

  - DTO 직접 조회(V4) →  `@XToOne` 관계 모두 페치 조인 + 컬렉션 DTO를 만들기 + 람다 루프를 활용⭕
  - 컬렉션 조회 최적화(V5) → 일대다 관계 컬렉션에 대해 IN절을 활용⭕

### 최종 결론

1. 엔티티 조회 방식으로 먼저 접근
  - 페치 조인 적용
    - 페이징 필요하다면  `@XToOne` 관계 모두 페치 조인 + `application.yml` 설정 파일에 `default_batch_fetch_size` 추가하여 배치 사이즈 조정
    - 페이징 필요없으면 일대다 컬렉션에 대해서도 페치 조인 적용


2. 엔티티 조회 방식으로 해결이 안되는 경우 DTO 조회 방식 사용

3. ~~DTO 조회 방식으로 해결이 안되면 Native SQL 혹은 스프링 JdbcTemplate~~