### PR TITLE
[Feat] : 자바 ORM 표준 JPA 프로그래밍 공부한 내용 정리

### DIFF
--- a/ex-hello-jpa/.gitignore
+++ b/ex-hello-jpa/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/ex-hello-jpa/.idea/.gitignore
+++ b/ex-hello-jpa/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/ex-hello-jpa/.idea/encodings.xml
+++ b/ex-hello-jpa/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/ex-hello-jpa/.idea/misc.xml
+++ b/ex-hello-jpa/.idea/misc.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="22" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/ex-hello-jpa/.idea/uiDesigner.xml
+++ b/ex-hello-jpa/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/ex-hello-jpa/.idea/vcs.xml
+++ b/ex-hello-jpa/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/ex-hello-jpa/pom.xml
+++ b/ex-hello-jpa/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>jpa-basic</groupId>
+    <artifactId>ex1-hello-jpa</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- JPA 하이버네이트 -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>6.4.2.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+
+        <!-- H2 데이터베이스 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.34</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/ex-hello-jpa/src/main/java/jpabasic/JpaRunner.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/JpaRunner.java
@@ -4,8 +4,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
-import jpabasic.domain.Member;
-import jpabasic.domain.Team;
+import jpabasic.domain.*;
 
 import java.util.List;
 
@@ -18,27 +17,24 @@ public class JpaRunner {
 		tx.begin();
 
 		try {
-			Team team = new Team();
-			team.setName("team");
-			em.persist(team);
-
-			Team newTeam = new Team();
-			newTeam.setName("이전할 팀");
-			em.persist(newTeam);
+			Item item = new Item();
+			item.setName("잡동사니");
+			em.persist(item);
 
 			Member member = new Member();
-			member.setName("member");
-			member.setTeam(team);
+			member.setName("고객");
 			em.persist(member);
 
-			em.flush();	// 영속성 컨텍스트 플러시 → 쓰기 지연 SQL 저장소에 등록된 쿼리를 DB에 반영
-			em.clear();	// 영속성 컨텍스트 초기화
+			// 잡동사니 상품 주문 추가
+			OrderItem orderItem = new OrderItem();
+			orderItem.setItem(item);
+			em.persist(orderItem);
 
-			Member findMember = em.find(Member.class, member.getId());// 1차 캐시에 없기에 우선적으로 DB를 조회하여 1차 캐시로 가져오고 영속성 컨텍스트에서 관리되도록
-			findMember.setTeam(newTeam);	// 새로운 팀으로 변경(수정)
-
-			findMember.setTeam(null);	// 엔티티 삭제(연관관계를 제거해줘야 에러가 발생하지 않는다.)
-			em.persist(findMember);
+			// 주문 생성
+			Order order = new Order();
+			order.setMember(member);
+			order.addOrderItem(orderItem);	// 연관관계 편의 메서드 사용
+			em.persist(order);
 
 			tx.commit();
 		} catch (Exception e) {

--- a/ex-hello-jpa/src/main/java/jpabasic/JpaRunner.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/JpaRunner.java
@@ -1,0 +1,26 @@
+package jpabasic;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
+
+public class JpaRunner {
+	public static void main(String[] args) {
+		EntityManagerFactory emf = Persistence.createEntityManagerFactory("hello");
+		EntityManager em = emf.createEntityManager();
+		EntityTransaction tx = em.getTransaction();
+
+		tx.begin();
+
+		try {
+
+			tx.commit();
+		} catch (Exception e) {
+			tx.rollback();
+		} finally {
+			em.close();
+		}
+		emf.close();
+	}
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/JpaRunner.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/JpaRunner.java
@@ -4,6 +4,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
+import jpabasic.domain.Member;
+import jpabasic.domain.Team;
 
 public class JpaRunner {
 	public static void main(String[] args) {
@@ -14,6 +16,14 @@ public class JpaRunner {
 		tx.begin();
 
 		try {
+			Team team = new Team();
+			team.setName("team");
+			em.persist(team);
+
+			Member member = new Member();
+			member.setName("member");
+			member.setTeam(team);
+			em.persist(member);
 
 			tx.commit();
 		} catch (Exception e) {

--- a/ex-hello-jpa/src/main/java/jpabasic/JpaRunner.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/JpaRunner.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Persistence;
 import jpabasic.domain.Member;
 import jpabasic.domain.Team;
 
+import java.util.List;
+
 public class JpaRunner {
 	public static void main(String[] args) {
 		EntityManagerFactory emf = Persistence.createEntityManagerFactory("hello");
@@ -24,6 +26,15 @@ public class JpaRunner {
 			member.setName("member");
 			member.setTeam(team);
 			em.persist(member);
+
+			Team findTeam = member.getTeam();
+			System.out.println("팀 이름: " + findTeam.getName());	// 객체 그래프 탐색
+
+			// team에 속한 모든 팀원을 조회하는 JPQL 쿼리문 작성해보기
+			List<Member> resultList = em.createQuery("select m from Member as m join m.team as t where t.name = :teamName", Member.class)
+					.setParameter("teamName", "team")
+					.getResultList();
+			resultList.forEach(m -> System.out.println(m.getName()));
 
 			tx.commit();
 		} catch (Exception e) {

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Address.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Address.java
@@ -1,0 +1,21 @@
+package jpabasic.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class Address {
+	private String street;
+	private String city;
+	private String zipcode;
+
+	public Address() {
+	}
+
+	public Address(String street, String city, String zipcode) {
+		this.street = street;
+		this.city = city;
+		this.zipcode = zipcode;
+	}
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Album.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Album.java
@@ -1,0 +1,15 @@
+package jpabasic.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@DiscriminatorValue("A")
+public class Album extends Item{
+	private String artist;
+	private String etc;
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Book.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Book.java
@@ -1,0 +1,15 @@
+package jpabasic.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@DiscriminatorValue("B")
+public class Book extends Item{
+	private String author;
+	private String isbn;
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Category.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Category.java
@@ -1,0 +1,30 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "CATEGORY")
+public class Category {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "category_id")
+	private Long id;
+	private String name;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "parent_id")
+	private Category parent;
+
+	@ManyToMany
+	@JoinTable(name = "CATEGORY_ITEM",
+		joinColumns = @JoinColumn(name = "category_id"),
+		inverseJoinColumns = @JoinColumn(name = "item_id"))
+	private List<Item> items = new ArrayList<>();
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Category.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Category.java
@@ -1,6 +1,7 @@
 package jpabasic.domain;
 
 import jakarta.persistence.*;
+import jpabasic.domain.baseentity.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,7 +12,7 @@ import java.util.List;
 @Getter
 @Setter
 @Table(name = "CATEGORY")
-public class Category {
+public class Category extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "category_id")

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Delivery.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Delivery.java
@@ -19,4 +19,7 @@ public class Delivery extends BaseEntity {
 	private String street;
 	private String zipcode;
 	private DeliveryStatus status;
+
+	@Embedded
+	private Address address;
 }

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Delivery.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Delivery.java
@@ -1,0 +1,21 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import jpabasic.domain.enumType.DeliveryStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "DELIVERY")
+public class Delivery {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "delivery_id")
+	private Long id;
+	private String city;
+	private String street;
+	private String zipcode;
+	private DeliveryStatus status;
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Delivery.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Delivery.java
@@ -1,6 +1,7 @@
 package jpabasic.domain;
 
 import jakarta.persistence.*;
+import jpabasic.domain.baseentity.BaseEntity;
 import jpabasic.domain.enumType.DeliveryStatus;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,7 +10,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Table(name = "DELIVERY")
-public class Delivery {
+public class Delivery extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "delivery_id")

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Item.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Item.java
@@ -1,0 +1,19 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "ITEM")
+public class Item {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "item_id")
+	private Long id;
+	private String name;
+	private int price;
+	private int stockQuantity;
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Item.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Item.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -16,4 +19,7 @@ public class Item {
 	private String name;
 	private int price;
 	private int stockQuantity;
+
+	@ManyToMany(mappedBy = "items")
+	private List<Category> categories = new ArrayList<>();
 }

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Item.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Item.java
@@ -1,6 +1,7 @@
 package jpabasic.domain;
 
 import jakarta.persistence.*;
+import jpabasic.domain.baseentity.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,8 +11,10 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
 @Table(name = "ITEM")
-public class Item {
+public abstract class Item extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "item_id")

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Member.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Member.java
@@ -1,0 +1,21 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "MEMBERS")
+public class Member {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+	private String name;
+
+	@ManyToOne(fetch = FetchType.LAZY)	// 지연 로딩 설정
+	@JoinColumn(name = "team_id")
+	private Team team;
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Member.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Member.java
@@ -19,4 +19,32 @@ public class Member extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)	// 지연 로딩 설정
 	@JoinColumn(name = "team_id")
 	private Team team;
+
+	@Embedded
+	private Period period;
+
+	/*
+	// 회원 주소
+	@Embedded
+	private Address homeAddress;
+
+	// 회사 주소
+	@Embedded
+	private Address companyAddress;
+	 */
+
+	// Caused by: org.hibernate.MappingException: Column 'city' is duplicated in mapping for entity 'jpabasic.domain.Member' (use '@Column(insertable=false, updatable=false)' when mapping multiple properties to the same column)
+	// 매핑 오류 발생 → 임베디드 타입 재정의 필요 → @AttributeOverrides와 @AttributeOverride 사용
+	// 임베디드 타입이 null이면 매핑 컬럼 값 모두 null이다.
+	@Embedded
+	private Address homeAddress;
+
+	@Embedded
+	@AttributeOverrides(
+			value = {
+					@AttributeOverride(name = "city", column = @Column(name = "company_city")),
+					@AttributeOverride(name = "street", column = @Column(name = "company_street")),
+					@AttributeOverride(name = "zipcode", column = @Column(name = "company_zipcode"))
+			})
+	private Address companyAddress;
 }

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Member.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Member.java
@@ -1,6 +1,7 @@
 package jpabasic.domain;
 
 import jakarta.persistence.*;
+import jpabasic.domain.baseentity.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,7 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Table(name = "MEMBERS")
-public class Member {
+public class Member extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "member_id")

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Movie.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Movie.java
@@ -1,0 +1,15 @@
+package jpabasic.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@DiscriminatorValue("M")
+public class Movie extends Item {
+	private String director;
+	private String actor;
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Order.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Order.java
@@ -1,0 +1,35 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import jpabasic.domain.enumType.OrderStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "ORDERS")
+public class Order {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "order_id")
+	private Long id;
+	private LocalDateTime orderDate;
+	private OrderStatus status;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@OneToMany(mappedBy = "order")
+	private List<OrderItem> orderItems = new ArrayList<>();
+
+	public void addOrderItem(OrderItem orderItem) {
+		orderItem.setOrder(this);
+		this.getOrderItems().add(orderItem);
+	}
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Order.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Order.java
@@ -28,6 +28,10 @@ public class Order {
 	@OneToMany(mappedBy = "order")
 	private List<OrderItem> orderItems = new ArrayList<>();
 
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "delivery_id")
+	private Delivery delivery;
+
 	public void addOrderItem(OrderItem orderItem) {
 		orderItem.setOrder(this);
 		this.getOrderItems().add(orderItem);

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Order.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Order.java
@@ -26,10 +26,12 @@ public class Order extends BaseEntity {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	@OneToMany(mappedBy = "order")
+	// 주문 엔티티를 관리함에 따라 주문상품 엔티티 역시 같이 관리됨
+	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<OrderItem> orderItems = new ArrayList<>();
 
-	@OneToOne(fetch = FetchType.LAZY)
+	// 주문 엔티티를 관리함에 따라 배송 엔티티 역시 같이 관리됨
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	@JoinColumn(name = "delivery_id")
 	private Delivery delivery;
 

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Order.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Order.java
@@ -1,6 +1,7 @@
 package jpabasic.domain;
 
 import jakarta.persistence.*;
+import jpabasic.domain.baseentity.BaseEntity;
 import jpabasic.domain.enumType.OrderStatus;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,7 +14,7 @@ import java.util.List;
 @Getter
 @Setter
 @Table(name = "ORDERS")
-public class Order {
+public class Order extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "order_id")

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/OrderItem.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/OrderItem.java
@@ -1,6 +1,7 @@
 package jpabasic.domain;
 
 import jakarta.persistence.*;
+import jpabasic.domain.baseentity.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,7 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Table(name = "ORDER_ITEM")	// ORDER - ITEM의 관계는 다대다 관계
-public class OrderItem {
+public class OrderItem extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "orderitem_id")

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/OrderItem.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/OrderItem.java
@@ -1,0 +1,26 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "ORDER_ITEM")	// ORDER - ITEM의 관계는 다대다 관계
+public class OrderItem {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "orderitem_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "item_id")
+	private Item item;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id")
+	private Order order;
+	private int orderPrice;
+	private int count;
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Period.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Period.java
@@ -1,0 +1,13 @@
+package jpabasic.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Embeddable
+@Getter
+public class Period {
+	private LocalDate startDate;
+	private LocalDate endDate;
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Team.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Team.java
@@ -1,6 +1,7 @@
 package jpabasic.domain;
 
 import jakarta.persistence.*;
+import jpabasic.domain.baseentity.BaseEntity;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,7 +12,7 @@ import java.util.List;
 @Getter
 @Setter
 @Table(name = "TEAM")
-public class Team {
+public class Team extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "team_id")

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/Team.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/Team.java
@@ -1,0 +1,23 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "TEAM")
+public class Team {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "team_id")
+	private Long id;
+	private String name;
+
+	@OneToMany(mappedBy = "team")
+	private List<Member> members = new ArrayList<>();
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/baseentity/BaseEntity.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/baseentity/BaseEntity.java
@@ -1,0 +1,15 @@
+package jpabasic.domain.baseentity;
+
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@MappedSuperclass
+public class BaseEntity {
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/enumType/DeliveryStatus.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/enumType/DeliveryStatus.java
@@ -1,0 +1,5 @@
+package jpabasic.domain.enumType;
+
+public enum DeliveryStatus {
+	COMP, READY
+}

--- a/ex-hello-jpa/src/main/java/jpabasic/domain/enumType/OrderStatus.java
+++ b/ex-hello-jpa/src/main/java/jpabasic/domain/enumType/OrderStatus.java
@@ -1,0 +1,5 @@
+package jpabasic.domain.enumType;
+
+public enum OrderStatus {
+	COMP, CANCEL
+}

--- a/ex-hello-jpa/src/main/resources/META-INF/persistence.xml
+++ b/ex-hello-jpa/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+    <persistence-unit name="hello">
+        <properties>
+            <!-- 필수 속성 -->
+            <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="jakarta.persistence.jdbc.user" value="sa"/>
+            <property name="jakarta.persistence.jdbc.password" value=""/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:tcp://localhost/~/hellodb"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+
+            <!-- 옵션 -->
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.use_sql_comments"  value="true"/>
+            <property name="hibernate.hbm2ddl.auto" value="create" />
+        </properties>
+    </persistence-unit>
+
+</persistence>


### PR DESCRIPTION
### JPA

- 자바 ORM 표준 JPA 프로그래밍 교재와 강의를 통해 공부한 내용을 정리

### 공부한 내용

- [ ] JPA 프로젝트 세팅

  - JPA 프로젝트 세팅
  - JPA는 특정 데이터베이스에 종속되는 것이 아님
  - `META-INF/persistence.xml` 설정 정보를 조회
  - 조회한 설정 정보를 기반으로 엔티티 매니저 팩토리 생성
  - 엔티티 매니저 팩토리에서 각각의 엔티티 매니저를 생성

- [ ] JPA 내부 구조

   - 영속성 컨텍스트 - 1차 캐시
   - 영속성 컨텍스트 - 동일성 보장
   - 영속성 컨텍스트 - 쓰기 지연 SQL 저장소
   - 영속성 컨텍스트 - 변경 감지
   - 영속성 컨텍스트 - 지연 로딩
   - 엔티티의 생명주기 이해(비영속/영속/준영속/삭제)
   - 엔티티 매니저 팩토리로부터 생성되는 엔티티 매니저는 각 스레드 간 공유되어선 안 된다.
   - 플러시(flush) : 영속성 컨텍스트 내용을 DB에 반영하는 작업(영속성 컨텍스트가 비워지는 것이 아님)

- [ ]  엔티티 매핑

  - 데이터베이스 스키마 자동 생성 기능
  - 기본 키 매핑과 매핑 전략
  - 직접 할당 : 기본 키를 애플리케이션에서 직접 할당
  - 자동 생성
    - IDENTITY : 기본 키 생성 방식을 데이터베이스에 위임
    - SEQUENCE : 데이터베이스 시퀀스를 사용해 기본 키 할당
    - TABLE : 키 생성 테이블 사용
  - ⭐IDENTITY : `persist()`는 영속성 컨텍스트에서 관리되는 대상이 되는 것으로 실제로 DB에 저장되지 않았기 때문에 식별자가 존재하지 않는 상황이다. 하지만 영속성 컨텍스트 내부의 1차 캐시에는 기본 키 식별자가 존재해야 하기 때문에 이 전략을 사용할 경우 트랜잭션 커밋 시점에 DB애 저장되어 식별자가 만들어진다. 해당 전략은 트랜잭션을 지원하는 쓰기 지연이 동작하지 않는다.
  - ⭐SEQUENCE : `persist()`를 호출할 때 데이터베이스 시퀀스를 사용해서 식별자를 조회하고 조회한 식별자를 엔티티에 할당한 후 엔티티를 영속성 컨텍스트에 저장, 이후 트랜잭션을 커밋해서 플러시가 발생하면 엔티티를 DB에 저장한다.

- [ ]  연관관계 매핑

  - 단방향 연관관계
  - 양방향 연관관계
  - 연관관계 주인 - 외래 키를 가지는 쪽이 연관관계의 주인이 된다.
  - 연관관계 편의 메서드(양방향 연관관계 시)

- [ ]  다양한 연관관계 매핑

  - 다대일 단방향⭐
  - 다대일 양방향⭐
  - 일대다 단방향 - 일(1)이 연관관계의 주인이 되는 것으로 보편적으로 테이블에서 외래 키를 다(N)쪽에서 관리되어 다른 테이블에 외래 키가 있기에 연관관계 처리를 위해 UPDATE SQL문이 실행된다는 단점이 존재
    - 정리 : **일대다 양방향❌ 다대일 양방향⭕**
  - 일대다 양방향
    - 정리 : 이런 개념은 없음,  다대일 양방향⭕
  - 다대다 단방향 - 매우 복잡해지므로 실무에서 사용 권장❌
  - 다대다 양방향 - 매우 복잡해지므로 실무에서 사용 권장❌
  - 일대일 - 게시판과 첨부 파일 간 관계를 예로 들어 설명한다면 게시판이 주테이블이 되고 첨부 파일이 대상 테이블이 된다. 주 테이블에서 외래 키를 관리하는 것을 선호한다.

- [ ]  고급 매핑

  - 상속 관계 매핑 전략
    - 조인 전략
    - 단일 테이블 전략
    - 구현 클래스마다 테이블 전략❌
  - 조인 전략 : 타입을 구분하는 컬럼을 추가
    - 장점 : 테이블 정규화, 외래 키 참조 무결성 제약조건 활용 가능, 저장 공간 효율적 사용 가능
    - 단점 : 조회 시 조인이 많이 사용되어 성능 저하 발생, 조회 쿼리 복잡, 데이터 등록 시 INSERT SQL 두 번 나간다.
  - 단일 테이블 전략 : 테이블 하나에 모든 것을 다 관리하므로 구분 컬럼은 필수
    - 장점 : 조인이 필요 없어 일반적으로 조회 성능이 빠르고 조회 쿼리가 단순
    - 단점 : 단일 테이블에 모든 것을 저장해 테이블에 커질 수 있다. 사용하지 않는 컬럼의 경우 전부 null이 들어가므로 부모 엔티티를 상속 받는 자식 엔티티가 매핑한 컬럼은 모두 null을 허용해야 한다.
  - `@MappedSuperClass` : 공통 매핑 정보를 제공하고 싶을 때 사용 

- [ ]  프록시와 연관관계 관리

  - 지연 로딩(LAZY Loading) : 엔티티가 실제 사용될 때까지 DB 조회를 미루는 방법
  - 실제 엔티티 객체 대신 DB 조회를 지연할 수 있는 가짜 객체를 만듦(프록시 객체)
  - 프록시 클래스는 실제 클래스를 상속 받아 만들어진 것으로 겉모양이 동일해 겉으로는 구분하기 어렵다. 타입 체크 시 프록시 클래스와 실제 클래스의 타입은 다르므로 이에 주의해서 사용해야 한다.
  - 프록시 객체는 실제 객체에 대한 참조를 보관한다. 프록시 객체의 메서드를 호출하면 실제 객체의 메서드를 호출한다.
  - 프록시 객체를 초기화한다고 해서 실제 엔티티로 바뀌는 것이 아니다. 프록시 객체가 초기화되면 프록시 객체를 통해서 실제 엔티티에 접근할 수 있는 것이다.
  - 영속성 컨텍스트에 찾는 엔티티가 있다면 DB를 조회할 필요가 없기에 `find()` 연산을 수행한 결과나 `getReference()` 연산을 수행한 결과 둘 다 프록시가 아닌 실제 엔티티를 반환하게 된다.
  - 초기화는 영속성 컨텍스트에서 관리되는 대상에 한해서 가능하다. 준영속 상태의 엔티티에 초기화를 수행하게 되면 문제가 발생한다.
  - 즉시 로딩(EAGER) : 엔티티를 조회할 때 연관된 엔티티도 함께 조회한다.
  - 지연 로딩(LAZY) : 연관된 엔티티를 실제 사용할 때 조회한다.
  - 영속성 전이(CASCADE) : 영속성 전이를 사용하면 연관된 엔티티도 함께 영속 상태로 관리된다.
    - 영속성 전이는 일대다, 일대일 연관관계에서 사용한다.
  - 고아 객체 : 부모 엔티티와 연관관계가 끊어진 자식 엔티티
    - JPA는 이런 고아 객체를 삭제하는 기능을 제공한다.
  - 영속성 전이 + 고아 객체 : 이 옵션을 같이 사용하면 부모 엔티티를 통해서 자식 엔티티 생명 주기를 관리할 수 있게 된다.

- [ ]  값 타입

  - 값 타입을 여러 엔티티에서 공유하면 위험하다.
  - 기본 타입의 경우 절대로 공유 참조가 발생하지 않으나 객체와 같은 참조 타입의 경우 공유 참조로 인한 사이드 이펙트가 발생할 수 있다. 이는 해결하기 어려운 부분이다.
  - 따라서 공유 참조로 인한 사이드 이펙트 발생을 방지하도록 하려면 불변 객체를 도입하는 것이 확실히 안전하다.
  - 불변하게 설계하는 것이 중요한데 이 때 엔티티의 각 필드에 `final` 키워드를 사용할 수 없다. 생성자로만 값을 설정할 수 있도록 하고 Getter만 열어두고 Setter는 닫는다.

- ⭐NULL 제약 조건과 JPA 조인 전략
  - NULL을 허용하지 않으면 내부 조인을 사용하여 성능이 훨씬 좋아진다.
  - NULL을 허용하면 외부 조인을 사용한다.
  - 두 조인 방식 중에서 더 좋은 것은 내부 조인이며 성능 최적화 시에 고민해야하는 요소

- ⭐일대다 컬렉션의 조회 성능 최적화
  - 일대다 조인을 하게 되면 결과적으로 일(1)에 해당하는 데이터가 다(N)에 해당하는 데이터의 갯수만큼 뻥튀기되는 현상이 발생한다.(외부 조인 개념 알고 있으면 이해됨)
  - 일대다 컬렉션 조회 성능 최적화를 위해 `distinct` 키워드를 통해 중복을 제거하는 방법 고려
  - 다대일, 일대일의 경우 조인을 하더라도 데이터가 뻥튀기되는 일이 없기 때문에 해당 연관관계의 경우 먼저 페치 조인을 수행한 후 `BatchSize`를 조절하여 성능 최적화를 도모
