### PR TITLE
[Feat] : JPQL(Java Persistence Query Language) 공부한 내용 정리하기

### DIFF
--- a/jpql/.gitignore
+++ b/jpql/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/jpql/.idea/.gitignore
+++ b/jpql/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/jpql/.idea/encodings.xml
+++ b/jpql/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/jpql/.idea/misc.xml
+++ b/jpql/.idea/misc.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="22" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/jpql/.idea/uiDesigner.xml
+++ b/jpql/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/jpql/.idea/vcs.xml
+++ b/jpql/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/jpql/pom.xml
+++ b/jpql/pom.xml
@@ -41,6 +41,13 @@
             <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.github.gavlyukovskiy/p6spy-spring-boot-starter -->
+        <dependency>
+            <groupId>com.github.gavlyukovskiy</groupId>
+            <artifactId>p6spy-spring-boot-starter</artifactId>
+            <version>1.9.1</version>
+        </dependency>
+
 
     </dependencies>
 

--- a/jpql/pom.xml
+++ b/jpql/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>jpa-basic</groupId>
-    <artifactId>ex1-hello-jpa</artifactId>
+    <artifactId>jpql</artifactId>
     <version>1.0.0</version>
 
     <properties>

--- a/jpql/pom.xml
+++ b/jpql/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>jpa-basic</groupId>
+    <artifactId>ex1-hello-jpa</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- JPA 하이버네이트 -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>6.4.2.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+
+        <!-- H2 데이터베이스 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.34</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/jpql/src/main/java/jpabasic/JpaRunner.java
+++ b/jpql/src/main/java/jpabasic/JpaRunner.java
@@ -41,28 +41,23 @@ public class JpaRunner {
 			em.flush();
 			em.clear();
 
-			// 상태 필드 연관 경로 탐색 - 명시적 조인(외부 조인)
-			// 검색하고자 하는 것 : Member
-			// 기준 : Member
-			// 조인 대상 : Team
-			List<Member> list = em.createQuery("select m from Member m join m.team t", Member.class)
+			// 컬렉션 필드 연관 경로 표현 - 묵시적 조인
+			List<Member> list = em.createQuery("select t.members from Team t", Member.class)
 					.getResultList();
 			for (Member member : list) {
-				String name = member.getUsername();
-				Integer age = member.getAge();
-				System.out.println(name + " : " + age);
+				System.out.println(member);
 			}
 
-			// 상태 필드 연관 경로 탐색 - 묵시적 조인(내부 조인)
-			// 검색하고자 하는 것 : Team
-			// 기준 : Member
-			// 조인 대상 : Team
-			List<Team> list1 = em.createQuery("select m.team from Member m", Team.class)
+			// 컬렉션 필드 연관 경로 표현 - 명시적 조인
+			List<Team> list1 = em.createQuery("select t from Team t join t.members", Team.class)
 					.getResultList();
 			for (Team t : list1) {
-				System.out.println(t.getName());
+				System.out.println("팀 이름 : " + t.getName());
+				List<Member> members = t.getMembers();
+				for (Member member : members) {
+					System.out.println("이름 : " + member.getUsername() + ", 나이 : " + member.getAge());
+				}
 			}
-
 
 			tx.commit();
 		} catch (Exception e) {

--- a/jpql/src/main/java/jpabasic/JpaRunner.java
+++ b/jpql/src/main/java/jpabasic/JpaRunner.java
@@ -1,0 +1,27 @@
+package jpabasic;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
+
+public class JpaRunner {
+	public static void main(String[] args) {
+		EntityManagerFactory emf = Persistence.createEntityManagerFactory("hello");
+		EntityManager em = emf.createEntityManager();
+		EntityTransaction tx = em.getTransaction();
+
+		tx.begin();
+
+		try {
+
+
+			tx.commit();
+		} catch (Exception e) {
+			tx.rollback();
+		} finally {
+			em.close();
+		}
+		emf.close();
+	}
+}

--- a/jpql/src/main/java/jpabasic/JpaRunner.java
+++ b/jpql/src/main/java/jpabasic/JpaRunner.java
@@ -38,19 +38,31 @@ public class JpaRunner {
 			m3.setTeam(team);
 			em.persist(m3);
 
-			// 단일 값 경로 탐색 (1)
-			List<Integer> list = em.createQuery("select m.age from Member m", Integer.class)
+			em.flush();
+			em.clear();
+
+			// 상태 필드 연관 경로 탐색 - 명시적 조인(외부 조인)
+			// 검색하고자 하는 것 : Member
+			// 기준 : Member
+			// 조인 대상 : Team
+			List<Member> list = em.createQuery("select m from Member m join m.team t", Member.class)
 					.getResultList();
-			for (Integer integer : list) {
-				System.out.println(integer);
+			for (Member member : list) {
+				String name = member.getUsername();
+				Integer age = member.getAge();
+				System.out.println(name + " : " + age);
 			}
 
-			// 단일 값 경로 탐색 (2)
-			List<String> list1 = em.createQuery("select m.username from Member m", String.class)
+			// 상태 필드 연관 경로 탐색 - 묵시적 조인(내부 조인)
+			// 검색하고자 하는 것 : Team
+			// 기준 : Member
+			// 조인 대상 : Team
+			List<Team> list1 = em.createQuery("select m.team from Member m", Team.class)
 					.getResultList();
-			for (String string : list1) {
-				System.out.println(string);
+			for (Team t : list1) {
+				System.out.println(t.getName());
 			}
+
 
 			tx.commit();
 		} catch (Exception e) {

--- a/jpql/src/main/java/jpabasic/JpaRunner.java
+++ b/jpql/src/main/java/jpabasic/JpaRunner.java
@@ -1,9 +1,12 @@
 package jpabasic;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.EntityTransaction;
-import jakarta.persistence.Persistence;
+import jakarta.persistence.*;
+import jpabasic.domain.Member;
+import jpabasic.domain.Order;
+import jpabasic.dto.AgeDTO;
+import jpabasic.dto.MemberDTO;
+
+import java.util.List;
 
 public class JpaRunner {
 	public static void main(String[] args) {
@@ -14,8 +17,105 @@ public class JpaRunner {
 		tx.begin();
 
 		try {
+			Member m1 = new Member();
+			m1.setUsername("m1");
+			m1.setAge(10);
 
+			Member m2 = new Member();
+			m2.setUsername("m2");
+			m2.setAge(15);
 
+			Member m3 = new Member();
+			m3.setUsername("m3");
+			m3.setAge(20);
+			
+			// distinct 테스트 위해 Member 객체 추가
+			Member m4 = new Member();
+			m4.setUsername("m4");
+			m4.setAge(20);
+			
+			em.persist(m1);
+			em.persist(m2);
+			em.persist(m3);
+			em.persist(m4);
+
+			em.flush();
+			em.clear();
+
+			// 반환할 타입을 명확히 지정할 수 있으면? → TypedQuery
+			TypedQuery<Member> query1 = em.createQuery("select m from Member m", Member.class);
+			List<Member> result1 = query1.getResultList();
+			result1.stream().forEach(m -> System.out.println(m.getUsername()));
+
+			em.flush();
+			em.clear();
+
+			// 반환할 타입을 명확히 지정할 수 없다면? → Query
+			Query query2 = em.createQuery("select m from Member m");
+			List result2 = query2.getResultList();
+			result2.stream().forEach(o -> System.out.println(((Member) o).getUsername()));
+
+			em.flush();
+			em.clear();
+
+			// 이름 파라미터 바인딩 적용
+			Member singleResult = em.createQuery("select m from Member m where m.username = :username", Member.class)
+					.setParameter("username", "m2")
+					.getSingleResult();
+			System.out.println(singleResult.getUsername());
+
+			em.flush();
+			em.clear();
+
+			// 엔티티 프로젝션(Ex. Member, Team)
+			// 엔티티 프로젝션의 경우 영속성 컨텍스트에서 관리된다.
+			List<Member> p1 = em.createQuery("select m.team from Member m", Member.class)
+					.getResultList();
+
+			// 임베디드 타입 프로젝션(Ex. Address)
+			// 임베디드 타입 프로젝션의 경우 영속성 컨텍스트에서 관리되지 않는다.
+			List<Order> p2 = em.createQuery("select o.address from Order o", Order.class)
+					.getResultList();
+
+			// 스칼라 타입 프로젝션(Ex. username, age)
+			List<Member> p3 = em.createQuery("select m.username from Member m", Member.class)
+					.getResultList();
+
+			// 여러 프로젝션 → Object[]
+			List<Object[]> p4 = em.createQuery("select m.username, m.age from Member m")
+					.getResultList();
+			for (Object[] objects : p4) {
+				String username = (String) objects[0];
+				Integer age = (Integer) objects[1];
+				System.out.println(username + " : " + age);
+			}
+
+			// 실제 애플리케이션 개발 시 DTO를 만들어 DTO 타입으로 변환
+			List<MemberDTO> p5 = em.createQuery("select new jpabasic.dto.MemberDTO(m.username, m.age) from Member m", MemberDTO.class)
+					.getResultList();
+			for (MemberDTO memberDTO : p5) {
+				String username = memberDTO.getUsername();
+				int age = memberDTO.getAge();
+				System.out.println(username + " : " + age);
+			}
+
+			// 페이징
+			// 예상 결과 : 나이 순 내림차순 정렬 m3 → m2 → m1
+			// 그 중에서 조회 시작 위치는 m2(setFirstResult(1)) 조회할 데이터 수는 2개(setMaxResults(2))
+			List<Member> paging = em.createQuery("select m from Member m order by m.age desc", Member.class)
+					.setFirstResult(1)
+					.setMaxResults(2)
+					.getResultList();
+			for (Member member : paging) {
+				System.out.println(member.getUsername());
+			}
+
+			// 예상 결과 : distinct로 중복을 제거하므로 10, 15, 20, 20 중에서 20이 중복 제거되어 한 번만 나옴
+			List<AgeDTO> list = em.createQuery("select distinct new jpabasic.dto.AgeDTO(m.age) from Member m", AgeDTO.class)
+					.getResultList();
+			for (AgeDTO ageDTO : list) {
+				System.out.println(ageDTO.getAge());
+			}
 			tx.commit();
 		} catch (Exception e) {
 			tx.rollback();

--- a/jpql/src/main/java/jpabasic/JpaRunner.java
+++ b/jpql/src/main/java/jpabasic/JpaRunner.java
@@ -49,14 +49,10 @@ public class JpaRunner {
 			}
 
 			// 컬렉션 필드 연관 경로 표현 - 명시적 조인
-			List<Team> list1 = em.createQuery("select t from Team t join t.members", Team.class)
+			List<Member> list1 = em.createQuery("select m from Team t join t.members m", Member.class)
 					.getResultList();
-			for (Team t : list1) {
-				System.out.println("팀 이름 : " + t.getName());
-				List<Member> members = t.getMembers();
-				for (Member member : members) {
-					System.out.println("이름 : " + member.getUsername() + ", 나이 : " + member.getAge());
-				}
+			for (Member member : list1) {
+				System.out.println(member);
 			}
 
 			tx.commit();

--- a/jpql/src/main/java/jpabasic/JpaRunner.java
+++ b/jpql/src/main/java/jpabasic/JpaRunner.java
@@ -15,100 +15,41 @@ public class JpaRunner {
 		tx.begin();
 
 		try {
-			Team team1 = new Team();
-			team1.setName("팀A");
-			em.persist(team1);
-
-			Team team2 = new Team();
-			team2.setName("팀B");
-			em.persist(team2);
+			// 주어진 케이스
+			Team team = new Team();
+			team.setName("team");
+			em.persist(team);
 
 			Member m1 = new Member();
-			Member m2 = new Member();
-			Member m3 = new Member();
-			Member m4 = new Member();
-			Member m5 = new Member();
-
-			m1.setTeam(team1);
-			m2.setTeam(team1);
-			m3.setTeam(team2);
-			m4.setTeam(team2);
-
+			m1.setUsername("member1");
+			m1.setAge(15);
+			m1.setTeam(team);
 			em.persist(m1);
+
+			Member m2 = new Member();
+			m2.setUsername("member2");
+			m2.setAge(16);
+			m2.setTeam(team);
 			em.persist(m2);
+
+			Member m3 = new Member();
+			m3.setAge(17);
+			m3.setUsername("member3");
+			m3.setTeam(team);
 			em.persist(m3);
-			em.persist(m4);
-			em.persist(m5);
 
-			em.flush();
-			em.clear();
-
-			// 엔티티 내부 조인
-			System.out.println("엔티티 내부 조인");
-			List<Member> join1 = em.createQuery("select m from Member m inner join m.team t", Member.class)
+			// 단일 값 경로 탐색 (1)
+			List<Integer> list = em.createQuery("select m.age from Member m", Integer.class)
 					.getResultList();
-			for (Member member : join1) {
-				System.out.println(member);
+			for (Integer integer : list) {
+				System.out.println(integer);
 			}
 
-			em.flush();
-			em.clear();
-			
-			// 엔티티 외부 조인
-			System.out.println("엔티티 외부 조인");
-			List<Member> join2 = em.createQuery("select m from Member m left join m.team t", Member.class)
+			// 단일 값 경로 탐색 (2)
+			List<String> list1 = em.createQuery("select m.username from Member m", String.class)
 					.getResultList();
-			for (Member member : join2) {
-				System.out.println(member);
-			}
-			
-			em.flush();
-			em.clear();
-			
-			// 컬렉션 조인
-			// 현재 팀A에 소속된 멤버는 총 4명
-			// 일대다 컬렉션 조인의 경우 다(N)에 해당하는 만큼의 데이터 뻥튀기가 발생하는 문제가 발생
-			System.out.println("일대다 컬렉션 조인");
-			List<Team> join3 = em.createQuery("select t from Team t join t.members", Team.class)
-					.getResultList();
-			for (Team t : join3) {
-				System.out.println(t.getName() + " : " + t.getMembers().size());
-			}
-			
-			em.flush();
-			em.clear();
-			
-			// 컬렉션 조인
-			// 현재 팀A에 소속된 멤버는 총 4명
-			// 위에서 제기된 일대다 컬렉션의 문제점을 해결하기 위해 애플리케이션 차원에서 중복을 제거하는 distinct 키워드를 지원
-			System.out.println("일대다 컬렉션 조인 - distinct 키워드");
-			List<Team> join4 = em.createQuery("select distinct t from Team t join t.members", Team.class)
-					.getResultList();
-			for (Team t : join4) {
-				System.out.println(t.getName() + " : " + t.getMembers().size());
-			}
-
-			em.flush();
-			em.clear();
-			
-			// 엔티티 페치 조인
-			// 팀과 멤버를 함께 조인하여 한 번에 가져옴
-			System.out.println("엔티티 페치 조인");
-			List<Member> join5 = em.createQuery("select m from Member m join fetch m.team t", Member.class)
-					.getResultList();
-			for (Member member : join5) {
-				System.out.println(member);
-			}
-
-			// 컬렉션 페치 조인 + distinct
-			System.out.println("컬렉션 페치 조인");
-			List<Team> join6 = em.createQuery("select distinct t from Team t join fetch t.members", Team.class)
-					.getResultList();
-			for (Team t : join6) {
-				System.out.println(t.getName());
-				for (Member member : t.getMembers()) {
-					System.out.println(member);
-				}
+			for (String string : list1) {
+				System.out.println(string);
 			}
 
 			tx.commit();

--- a/jpql/src/main/java/jpabasic/domain/Address.java
+++ b/jpql/src/main/java/jpabasic/domain/Address.java
@@ -1,0 +1,12 @@
+package jpabasic.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class Address {
+	private String city;
+	private String street;
+	private String zipcode;
+}

--- a/jpql/src/main/java/jpabasic/domain/Member.java
+++ b/jpql/src/main/java/jpabasic/domain/Member.java
@@ -1,0 +1,28 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "MEMBERS")
+public class Member {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "member_id")
+	private Long id;
+	private String username;
+	private int age;
+
+	@OneToMany(mappedBy = "member")
+	private List<Order> orders = new ArrayList<>();
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "team_id")
+	private Team team;
+}

--- a/jpql/src/main/java/jpabasic/domain/Order.java
+++ b/jpql/src/main/java/jpabasic/domain/Order.java
@@ -1,0 +1,28 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "ORDERS")
+public class Order {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "order_id")
+	private Long id;
+	private int orderAmount;
+
+	@Embedded
+	private Address address;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "product_id")
+	private Product product;
+}

--- a/jpql/src/main/java/jpabasic/domain/Product.java
+++ b/jpql/src/main/java/jpabasic/domain/Product.java
@@ -1,0 +1,18 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Product {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "product_id")
+	private Long id;
+	private String name;
+	private int price;
+	private int stockAmount;
+}

--- a/jpql/src/main/java/jpabasic/domain/Team.java
+++ b/jpql/src/main/java/jpabasic/domain/Team.java
@@ -1,0 +1,16 @@
+package jpabasic.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Team {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "team_id")
+	private Long id;
+	private String name;
+}

--- a/jpql/src/main/java/jpabasic/domain/Team.java
+++ b/jpql/src/main/java/jpabasic/domain/Team.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -13,4 +16,7 @@ public class Team {
 	@Column(name = "team_id")
 	private Long id;
 	private String name;
+
+	@OneToMany(mappedBy = "team")
+	private List<Member> members = new ArrayList<>();
 }

--- a/jpql/src/main/java/jpabasic/dto/AgeDTO.java
+++ b/jpql/src/main/java/jpabasic/dto/AgeDTO.java
@@ -1,0 +1,12 @@
+package jpabasic.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AgeDTO {
+	private int age;
+
+	public AgeDTO(int age) {
+		this.age = age;
+	}
+}

--- a/jpql/src/main/java/jpabasic/dto/MemberDTO.java
+++ b/jpql/src/main/java/jpabasic/dto/MemberDTO.java
@@ -1,0 +1,14 @@
+package jpabasic.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberDTO {
+	private String username;
+	private int age;
+
+	public MemberDTO(String username, int age) {
+		this.username = username;
+		this.age = age;
+	}
+}

--- a/jpql/src/main/resources/META-INF/persistence.xml
+++ b/jpql/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
+    <persistence-unit name="hello">
+        <properties>
+            <!-- 필수 속성 -->
+            <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="jakarta.persistence.jdbc.user" value="sa"/>
+            <property name="jakarta.persistence.jdbc.password" value=""/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:tcp://localhost/~/jpqlex"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+
+            <!-- 옵션 -->
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.use_sql_comments"  value="true"/>
+            <property name="hibernate.hbm2ddl.auto" value="create" />
+        </properties>
+    </persistence-unit>
+
+</persistence>


### PR DESCRIPTION
### JPQL

- JPQL에 대해 공부한 내용을 정리

### 공부한 내용

- [ ] JPQL

  - 엔티티 객체를 조회하는 객체지향 쿼리
  - SQL을 추상화해서 특정 데이터베이스에 종속되지 않는다.
  - JPQL은 결국 SQL로 변환된다.

- [ ] 기본 문법과 쿼리 API

  - 반환 타입이 명확하게 지정된다면? → `TypedQuery` 사용
  - 반환 타입이 명확하게 지정되지 않는다면? → `Query` 사용
  - 파라미터 바인딩(이름 기준 파라미터 사용 권장)
 
- [ ] 프로젝션

  - 엔티티 프로젝션
    - 엔티티 프로젝션의 경우 조회한 엔티티는 영속성 컨텍스트에서 관리된다. 
  - 임베디드 타입 프로젝션
    - 임베디드 타입은 엔티티 타입이 아닌 값 타입이다.
    - 따라서, 영속성 컨텍스트에서 관리되지 않는다. 
  - 스칼라 타입 프로젝션
  - 여러 값 프로젝션
    - 반환 타입이 명확하지 않기 떄문에 `Query` 타입을 사용하게 되는데 이 떄, 기본적으로 `Object[]`를 지원한다. 이렇게 되면 해당 엔티티 타입으로 다운 캐스팅을 수행해야하는데 이런 번거로움을 해소하기 위해 별도의 DTO를 만들고 `new` 연산자를 활용하여 DTO의 생성자를 호출하는 방식으로도 작성이 가능하다. 이 때, `new` 연산자를 사용할 떄 전체 패키지 경로를 작성해야 한다.

- [ ] 페이징 API

  - `setFirstResult()` : 조회 시작 위치 지정
  - `setMaxResult()` : 조회할 데이터 수

- [ ] 조인⭐

  - 내부 조인(Inner Join)
  - 외부 조인(Outer Join)
  - 컬렉션 조인(Collection Join)⭐
    - 다대일 관계(Ex. 회원 → 팀) → `member.team`을 사용하므로 단일 값 연관 필드
    - 일대다 관계(Ex. 팀 → 회원)  → `team.members`을 사용하므로 컬렉션 값 연관 필드
  - 페치 조인(Fetch Join)⭐
    - SQL에서 지원하는 개념이 아니고 JPQL에서 성능 최적화를 위해 지원하는 기능
    - 연관된 엔티티나 컬렉션을 한 번의 쿼리로 조회할 수 있다.
    - 이 때, 지연 로딩으로 설정했다 하더라도 연관된 실제 엔티티가 같이 조회되는 것이므로 프록시 타입으로 조회되지 않아 지연 로딩이 적용되지 않는다.
    - 일대다 컬렉션 페치 조인 주의 사항⭐
      - 일대다 조인의 경우 일(1)에 해당하는 데이터가 다(N)에 해당하는 데이터의 개수만큼 뻥튀기가 된다.
      - 이 때, 페치 조인과 함께 중복 제거 키워드인 `distinct`를 사용한다.
      - 추후 나중에 배우는 BatchSize로 조절 가능하다.
    - 페치 조인과 일반 조인의 차이
      - JPQL은 결과를 반환할 떄 연관관게를 고려하지 않는다.
      - 예를 들어, 팀 엔티티를 조회한다고 가정할 떄 팀 엔티티만 조회하는 것이지 이와 연관된 엔티티인 회원 엔티티가 같이 조회되는 것이 아니라는 것이다.
      - 반면, 페치 조인을 사용하면 연관된 엔티티도 함께 조회한다.
    - 페치 조인의 특징과 한계⭐ 
      -  최적화를 위해 글로벌 로딩 전략을 즉시 로딩으로 설정할 경우 일부 기능에서 빠른 성능을 자랑할 수 있으나 전체적으로 보면 사용하지 않는 엔티티가 자주 로딩되어 전체 애플리케이션 성능에 악영향을 미칠 수 있다.
      - 따라서 글로벌 로딩 전략을 지연 로딩으로 설정하고 최적화가 필요한 경우를 마주하면 페치 조인을 사용한다.
      - 페치 조인 대상에는 별칭을 줄 수 없다. → 엄밀히 따지면 JPA는 페치 조인 대상에 별칭을 주지 못하는데 하이버네이트가 이를 지원한다. 애플리케이션에서 페치 조인의 결과는 연관된 모든 엔티티가 있을 것이라고 가정하고 사용해야 하는데 페치 조인에 별칭을 잘못 사용해서 컬렉션 결과를 필터링할 경우 2차 캐시와 함께 사용하는 곳에서 연관된 데이터 수가 달라져 객체와 DB 상태가 일관성을 유지하지 못하는 문제가 발생한다.
      - 둘 이상의 컬렉션을 패치할 수 없다.
      - 일대다 컬렉션을 페치 조인하는 경우에는 페이징 API를 사용할 수 없다. 하이버네이트에서 컬렉션을 페치 조인하고 페이징 API를 사용하면 메모리에서 페이징 처리를 하게 되는데 데이터가 많으면 성능 이슈와 메모리 초과 예외가 발생할 수 있어 위험하다.

- [ ] 경로 표현식

  - 상태 필드 경로
  - 단일 값 연관 경로
    - 묵시적 조인을 사용하면 항상 내부 조인이 발생한다.
    - 명시적 조인을 사용하면 외부 조인이 발생한다.
  - 컬렉션 값 연관 경로
    - 묵시적 조인을 사용하면 항상 내부 조인이 발생한다.
    - 명시적 조인을 사용하면 외부 조인이 발생한다. 

- [ ] 경로 탐색을 사용한 묵시적 조인 시 주의사항
```java
// 컬렉션 필드 연관 경로 표현 - 묵시적 조인
List<Member> list = em.createQuery("select t.members from Team t", Member.class)
	.getResultList();
for (Member member : list) {
    System.out.println(member);
}

// 컬렉션 필드 연관 경로 표현 - 명시적 조인
List<Member> list1 = em.createQuery("select m from Team t join t.members m", Member.class)
	.getResultList();
for (Member member : list1) {
    System.out.println(member);
}
```

쿼리문 비교

```sql
/* select
    t.members 
from
    Team t */ select
        m1_0.member_id,
        m1_0.age,
        t1_0.team_id,
        t1_0.name,
        m1_0.username 
    from
        Team t1_0 
    join
        MEMBERS m1_0 
            on t1_0.team_id=m1_0.team_id

/* select
    m 
from
    Team t 
join
    t.members m */ select
        m1_0.member_id,
        m1_0.age,
        t1_0.team_id,
        t1_0.name,
        m1_0.username 
    from
        Team t1_0 
    join
        MEMBERS m1_0 
            on t1_0.team_id=m1_0.team_id
```

결과적으로 보면 실행되는 쿼리문은 묵시적 조인이나 명시적 조인이나 같다. 묵시적 조인은 조인이 일어나는 상황을 한 눈에 파악하기 어렵다는 단점이 있다. 애플리케이션의 규모가 작고 단순하고 성능에 이슈가 없다고 판단되면 묵시적 조인을 사용해도 크게 문제가 되지 않으나 규모가 크고 복잡하며 성능과 직결되는 부분이라면 명시적 조인을 사용하는 것이 좋다.